### PR TITLE
Add cop enforcing ApplicationRecord.transaction

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -131,6 +131,3 @@ Style/StringLiterals:
 
 Style/StringLiteralsInInterpolation:
   EnforcedStyle: double_quotes
-
-Custom/EnforceApplicationRecordTransaction:
-  Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -131,3 +131,6 @@ Style/StringLiterals:
 
 Style/StringLiteralsInInterpolation:
   EnforcedStyle: double_quotes
+
+Custom/EnforceApplicationRecordTransaction:
+  Enabled: true

--- a/rubocop/cops/custom/enforce_application_record_transaction.rb
+++ b/rubocop/cops/custom/enforce_application_record_transaction.rb
@@ -1,0 +1,34 @@
+module RuboCop
+  module Cops
+    module Custom
+      # Enforce using ApplicationRecord.transaction for transaction blocks.
+      class EnforceApplicationRecordTransaction < ::RuboCop::Cop::Base
+        MSG = "Use ApplicationRecord.transaction for transaction blocks.".freeze
+
+        def on_send(node)
+          return unless node.method?(:transaction)
+          return unless transaction_block_call?(node)
+          return if application_record_receiver?(node.receiver)
+
+          add_offense(node.loc.selector, message: MSG)
+        end
+
+        alias on_csend on_send
+
+        private
+
+        def application_record_receiver?(receiver)
+          return false unless receiver&.const_type?
+
+          ["ApplicationRecord", "::ApplicationRecord"].include?(receiver.const_name)
+        end
+
+        def transaction_block_call?(node)
+          parent = node.parent
+
+          parent&.block_type? && parent.send_node.equal?(node)
+        end
+      end
+    end
+  end
+end

--- a/rubocop/cops/custom/enforce_application_record_transaction.rb
+++ b/rubocop/cops/custom/enforce_application_record_transaction.rb
@@ -8,6 +8,7 @@ module RuboCop
         def on_send(node)
           return unless node.method?(:transaction)
           return unless transaction_block_call?(node)
+          return if node.receiver.nil?
           return if application_record_receiver?(node.receiver)
 
           add_offense(node.loc.selector, message: MSG)

--- a/spec/rubocop/cops/custom/enforce_application_record_transaction_spec.rb
+++ b/spec/rubocop/cops/custom/enforce_application_record_transaction_spec.rb
@@ -1,0 +1,40 @@
+require_relative "../../../spec_helper"
+require_relative "../../../../rubocop/cops/custom/enforce_application_record_transaction"
+
+RSpec.describe RuboCop::Cops::Custom::EnforceApplicationRecordTransaction do
+  let(:config) { RuboCop::Config.new("Custom/EnforceApplicationRecordTransaction" => { "Enabled" => true }) }
+  let(:cop) { described_class.new(config) }
+
+  it "does not register an offense for ApplicationRecord.transaction" do
+    expect_no_offenses(<<~RUBY)
+      ApplicationRecord.transaction { do_stuff }
+    RUBY
+  end
+
+  it "registers an offense for ActiveRecord::Base.transaction" do
+    expect_offense(<<~RUBY)
+      ActiveRecord::Base.transaction { do_stuff }
+                         ^^^^^^^^^^^ Use ApplicationRecord.transaction for transaction blocks.
+    RUBY
+  end
+
+  it "registers an offense for instance transaction calls" do
+    expect_offense(<<~RUBY)
+      auction.transaction { do_stuff }
+              ^^^^^^^^^^^ Use ApplicationRecord.transaction for transaction blocks.
+    RUBY
+  end
+
+  it "registers an offense for implicit receiver transaction calls" do
+    expect_offense(<<~RUBY)
+      transaction { do_stuff }
+      ^^^^^^^^^^^ Use ApplicationRecord.transaction for transaction blocks.
+    RUBY
+  end
+
+  it "does not register offenses for non-block transaction method usage" do
+    expect_no_offenses(<<~RUBY)
+      transaction.id
+    RUBY
+  end
+end

--- a/spec/rubocop/cops/custom/enforce_application_record_transaction_spec.rb
+++ b/spec/rubocop/cops/custom/enforce_application_record_transaction_spec.rb
@@ -25,10 +25,9 @@ RSpec.describe RuboCop::Cops::Custom::EnforceApplicationRecordTransaction do
     RUBY
   end
 
-  it "registers an offense for implicit receiver transaction calls" do
-    expect_offense(<<~RUBY)
+  it "does not register an offense for implicit receiver transaction calls" do
+    expect_no_offenses(<<~RUBY)
       transaction { do_stuff }
-      ^^^^^^^^^^^ Use ApplicationRecord.transaction for transaction blocks.
     RUBY
   end
 


### PR DESCRIPTION
## Summary
- add `Custom/EnforceApplicationRecordTransaction`
- enable the cop in RuboCop config
- add cop spec coverage for good and bad usage patterns